### PR TITLE
Fix zsh prompt

### DIFF
--- a/quests/helloworld/home/.zshrc
+++ b/quests/helloworld/home/.zshrc
@@ -1,9 +1,9 @@
-PROMPT='%n@%m:%~%# '
+PROMPT='%F{2}%n%f:%~ $ '
 unsetopt CASE_GLOB
 setopt CHASE_LINKS
 emulate bash
 
-typeset -A cmd
+set +o prompt_cr
 
 preexec() {
     export CMD_START_TIME=$(date +%s%N)      # capture start time

--- a/quests/helloworld/home/.zshrc
+++ b/quests/helloworld/home/.zshrc
@@ -1,4 +1,4 @@
-PROMPT='%F{2}%n%f:%~ $ '
+PROMPT='%F{2}%n%f:%F{6}%~%f $ '
 unsetopt CASE_GLOB
 setopt CHASE_LINKS
 emulate bash


### PR DESCRIPTION
* fix the trailing '%' in front of every prompt.
* add color and update the prompt (only consist username and pwd now)

https://github.com/xtermjs/xterm.js/issues/2564
https://unix.stackexchange.com/questions/167582/why-zsh-ends-a-line-with-a-highlighted-percent-symbol
https://zsh.sourceforge.io/Doc/Release/Options.html